### PR TITLE
Don't fix the version of libboost-dev

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dindel-tgi1.01-wu1 (1.01-wu1-3) UNRELEASED; urgency=low
+
+  * Attempt to fix install on ubuntu precise
+
+ -- Avi Ramu <aramu@genome.wustl.edu>  Thu, 05 Mar 2015 14:49:59 -0600
+
 dindel-tgi1.01-wu1 (1.01-wu1-2) UNRELEASED; urgency=low
 
   * Attempt to break dindel-tgi1.01

--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Genome Developers <genome-dev@genome.wustl.edu>
 DM-Upload-Allowed: yes
 Uploaders: Genome Developers <genome-dev@genome.wustl.edu>
-Build-Depends: debhelper (>= 7), git-core, libboost1.40-dev,
+Build-Depends: debhelper (>= 7), git-core, libboost-dev,
  libboost-program-options-dev
 Standards-Version: 3.9.2
 Homepage: https://github.com/genome/dindel-tgi

--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Maintainer: Genome Developers <genome-dev@genome.wustl.edu>
 DM-Upload-Allowed: yes
 Uploaders: Genome Developers <genome-dev@genome.wustl.edu>
 Build-Depends: debhelper (>= 7), git-core, libboost-dev,
- libboost-program-options-dev
+ libboost-program-options-dev libncurses5-dev
 Standards-Version: 3.9.2
 Homepage: https://github.com/genome/dindel-tgi
 

--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Maintainer: Genome Developers <genome-dev@genome.wustl.edu>
 DM-Upload-Allowed: yes
 Uploaders: Genome Developers <genome-dev@genome.wustl.edu>
 Build-Depends: debhelper (>= 7), git-core, libboost-dev,
- libboost-program-options-dev libncurses5-dev
+ libboost-program-options-dev, libncurses5-dev
 Standards-Version: 3.9.2
 Homepage: https://github.com/genome/dindel-tgi
 


### PR DESCRIPTION
Fixing the version of libboost-dev to 1.40 breaks the install of genome-snapshot-deps on precise since this version of the package is unavailable.
